### PR TITLE
Feature: Bulk actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "experiment",
+    "name": "nendo-web",
     "private": true,
-    "version": "0.0.0",
+    "version": "0.1.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -608,6 +608,7 @@ async function getTracks() {
             reset_paging: true
         })
     }
+    console.log(trackStore.num_results)
 
     await getTracksScroll()
 

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -1005,7 +1005,7 @@ function onDragStart($event, track) {
                     </thead>
                     <tbody>
                         <template v-for="(track, index) in trackStore.tracks" :key="track.id">
-                            <tr class="select-none group text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-ngreytransparent draggable" draggable="true" @dragstart="onDragStart($event, track)" :class="{ 'bg-gray-100 dark:bg-ngreytransparent border-t dark:border-black' : track.isOpen, 'bg-blue-100 dark:bg-blue-800' : isTrackSelected(track)}" @click="trackDetailsToggle(track, $event)" @mouseenter="contextMenuClose(track)">
+                            <tr class="select-none group text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-ngreytransparent draggable" draggable="true" @dragstart="onDragStart($event, track)" :class="{ 'bg-gray-100 dark:bg-ngreytransparent border-t dark:border-black' : track.isOpen, 'bg-blue-100 dark:bg-blue-800' : isTrackSelected(track.id)}" @click="trackDetailsToggle(track, $event)" @mouseenter="contextMenuClose(track)">
                                 <td class="w-5 py-2 px-4 text-right min-w-[50px] relative" @click="track_play(track)" @click.stop>
                                     <div
                                         class="h-[40px] w-[40px] rounded bg-cover relative cursor-pointer"

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -211,11 +211,10 @@ const collectionModalClose = async (data) => {
             trackStore.tracks[trackIndex] = JSON.parse(JSON.stringify(trackStore.track))
         }
     }
-    if (data.track.value === 'bulk'){
-        if (router.currentRoute.value.name === 'collection'){
-            await collectionStore.fetchCollection(route.params.id)
-        }
-        getTracks()
+    if (router.currentRoute.value.name === 'collection'){
+        await collectionStore.fetchCollection(route.params.id)
+        collectionSelector.value.collectionSelected = [collectionStore.collection]
+        await getTracks()
     }
 }
 
@@ -490,6 +489,10 @@ const deleteTrack = async (track) => {
             )
             if (deletedTrackId !== -1) {
                 trackStore.tracks.splice(deletedTrackId, 1);
+                if (router.currentRoute.value.name === 'collection'){
+                    await collectionStore.fetchCollection(route.params.id)
+                    collectionSelector.value.collectionSelected = [collectionStore.collection]
+                }
             } else {
                 await getTracks()
             }
@@ -518,6 +521,7 @@ const bulkDelete = async () => {
         })
         if (router.currentRoute.value.name === 'collection'){
             await collectionStore.fetchCollection(route.params.id)
+            collectionSelector.value.collectionSelected = [collectionStore.collection]
         }
         getTracks()
     }
@@ -589,6 +593,7 @@ async function getTracks() {
             reset_paging: true,
             track_type: trackTypeSettings.value.value
         })
+        lastVisitedId.value = ''
     }
     if (router.currentRoute.value.name === 'collection') {
         if (lastVisitedId.value !== route.params.id) {

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -247,8 +247,6 @@ const trackCreationModalClose = async (response) => {
 
 
 // Row Display
-
-
 const showTrackTitleWithFallback = (track, index) => {
     if (track.meta && track.meta.title){ 
         return track.meta.title
@@ -696,6 +694,15 @@ async function getTracks() {
         trackStore.track.plugin_data = metafake
     }
 }
+
+function onDragStart($event, track) {
+    if (selectedTracks.value.length === 0) {
+        browserStore.draggableTracks = [track]
+    } else {
+        browserStore.draggableTracks = selectedTracks.value
+    }
+}
+
 </script>
 
 <template>
@@ -982,7 +989,7 @@ async function getTracks() {
                     </thead>
                     <tbody>
                         <template v-for="(track, index) in trackStore.tracks" :key="track.id">
-                            <tr class="select-none group text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-ngreytransparent" :class="{ 'bg-gray-100 dark:bg-ngreytransparent border-t dark:border-black' : track.isOpen, 'bg-blue-100 dark:bg-blue-800' : isTrackSelected(track)}" @click="trackDetailsToggle(track, $event)" @mouseenter="contextMenuClose(track)">
+                            <tr class="select-none group text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-ngreytransparent draggable" draggable="true" @dragstart="onDragStart($event, track)" :class="{ 'bg-gray-100 dark:bg-ngreytransparent border-t dark:border-black' : track.isOpen, 'bg-blue-100 dark:bg-blue-800' : isTrackSelected(track)}" @click="trackDetailsToggle(track, $event)" @mouseenter="contextMenuClose(track)">
                                 <td class="w-5 py-2 px-4 text-right min-w-[50px] relative" @click="track_play(track)" @click.stop>
                                     <div
                                         class="h-[40px] w-[40px] rounded bg-cover relative cursor-pointer"
@@ -1002,7 +1009,7 @@ async function getTracks() {
                                     </div>
                                 </td>
                                 <td class="pr-2 pl-0">
-                                    <div class="font-medium hover:underline inline-block" @click="gotoTrack(track)" @click.stop :class="{'text-ngreenhover': track.id === currentTrack.id}">
+                                    <div class="font-medium hover:underline inline-block dragclone" @click="gotoTrack(track)" @click.stop :class="{'text-ngreenhover': track.id === currentTrack.id}">
                                         {{ showTrackTitleWithFallback(track, index) }}
                                     </div>
                                     <div>
@@ -1185,5 +1192,8 @@ input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-results-button,
 input[type="search"]::-webkit-search-results-decoration { display: none; }
-
+.draggable {
+    cursor: grab;
+    touch-action: none; /* This line is important to make it work on touch devices */
+}
 </style>

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -271,9 +271,9 @@ const trackDetailsToggle = (track, event) => {
     event.stopPropagation()
 
     if (event.shiftKey) {
-        const index = selectedTracks.value.findIndex(t => t.id === track.id);
+        const index = selectedTracks.value.findIndex(tid => tid === track.id);
         if (index === -1) {
-            selectedTracks.value.push(track);
+            selectedTracks.value.push(track.id);
         } else {
             selectedTracks.value.splice(index, 1);
         }
@@ -285,7 +285,7 @@ const trackDetailsToggle = (track, event) => {
 }
 
 const isTrackSelected = computed(() => {
-    return (track) => selectedTracks.value.includes(track);
+    return (trackId) => selectedTracks.value.includes(trackId);
 })
 
 
@@ -532,15 +532,12 @@ const bulkDelete = async () => {
 const selectionDelete = async () => {
     let text = `Delete all selected Tracks${router.currentRoute.value.name === 'collection' ? ' in this collection' : ''}?`
     if (confirm(text) == true) {
-        // bulkContextMenu.value = false
-        // await trackStore.deleteTracks({
-        //     collection_id: router.currentRoute.value.name === 'collection' ? route.params.id : "",
-        //     track_type: trackTypeSettings.value.value
-        // })
-        // if (router.currentRoute.value.name === 'collection'){
-        //     await collectionStore.fetchCollection(route.params.id)
-        //     collectionSelector.value.collectionSelected = [collectionStore.collection]
-        // }
+        bulkContextMenu.value = false
+        await trackStore.deleteSelectedTracks(selectedTracks.value)
+        if (router.currentRoute.value.name === 'collection'){
+            await collectionStore.fetchCollection(route.params.id)
+            collectionSelector.value.collectionSelected = [collectionStore.collection]
+        }
         getTracks()
     }
 }
@@ -626,7 +623,6 @@ async function getTracks() {
             reset_paging: true
         })
     }
-    console.log(trackStore.num_results)
 
     await getTracksScroll()
 
@@ -795,8 +791,8 @@ async function getTracks() {
             <div class="px-4 py-1.5 pb-2 text-sm h-[44px] dark:h-[45px] bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold">
                 <div class="flex gap-2 w-full">
                     <div class="py-1.5">
-                        <template v-if="selectedTracks.length === 0"> 
-                            {{ trackStore.tracks.length }} Results
+                        <template v-if="!selectedTracks.length"> 
+                            {{ trackStore.num_results }} Results
                         </template>
                         <template v-else>
                             {{ selectedTracks.length }} selected
@@ -892,7 +888,7 @@ async function getTracks() {
                 </template>
 
                 <div class="p-4 items-center text-sm h-[44px] dark:h-[45px] bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold">
-                    <div>Related</div>
+                    <div>{{ trackStore.num_results }} Related</div>
                 </div>
             </template>
 
@@ -982,7 +978,7 @@ async function getTracks() {
                     </thead>
                     <tbody>
                         <template v-for="(track, index) in trackStore.tracks" :key="track.id">
-                            <tr class="select-none group text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-ngreytransparent" :class="{ 'bg-gray-100 dark:bg-ngreytransparent border-t dark:border-black' : track.isOpen, 'bg-blue-100 dark:bg-blue-800' : isTrackSelected(track)}" @click="trackDetailsToggle(track, $event)" @mouseenter="contextMenuClose(track)">
+                            <tr class="select-none group text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-ngreytransparent" :class="{ 'bg-gray-100 dark:bg-ngreytransparent border-t dark:border-black' : track.isOpen, 'bg-blue-100 dark:bg-blue-800' : isTrackSelected(track.id)}" @click="trackDetailsToggle(track, $event)" @mouseenter="contextMenuClose(track)">
                                 <td class="w-5 py-2 px-4 text-right min-w-[50px] relative" @click="track_play(track)" @click.stop>
                                     <div
                                         class="h-[40px] w-[40px] rounded bg-cover relative cursor-pointer"
@@ -1146,7 +1142,7 @@ async function getTracks() {
         </modal>
     </div>
     <modal :open="browserStore.collectionModal" @update:open="collectionModalCloseCall()" title="">   
-        <Collection :track="collectionTrack" :trackTypeFilter="trackTypeSettings.value" :collection="collectionStore.collection" @modalClosed="collectionModalClose" ref="collectionModalRef"></Collection>
+        <Collection :track="collectionTrack" :selected-track-ids="selectedTracks" :track-type-filter="trackTypeSettings.value" :collection="collectionStore.collection" @modalClosed="collectionModalClose" ref="collectionModalRef"></Collection>
     </modal>
     <Tools :modalopen="browserStore.toolViewActive" @click="browserStore.toolViewActive = !browserStore.toolViewActive" @modalClosed="browserStore.toolViewActive = false"></Tools>
     <TrackCreation :track="trackCreationTrack" :modalopen="trackCreationModal" @click="trackCreationModal = !trackCreationModal" @modalClosed="trackCreationModalClose"></TrackCreation>

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -201,7 +201,7 @@ const collectionModalClose = async (data) => {
     } else {
         router.push({ path: '/library/' })
     }
-    if(data.addTrack.value && data.track.value !== 'bulk') {
+    if(data.addTrack.value && data.track.value !== 'bulk' && data.track.value !== 'selection') {
         await trackStore.fetchTrack(data.track.value.id)
         // update track on collection assign
         if (router.currentRoute.value.name === 'library' || router.currentRoute.value.name === 'collection') { 

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -774,7 +774,13 @@ function onDragStart($event, track) {
         <div v-if="filters" class="border-b dark:border-b dark:border-black">   
             <Filters :filtersettings="filtersettings" @updateFilters="handleUpdateFilter"></Filters>
         </div>
-        <template v-if="router.currentRoute.value.name === 'collection'">
+        <template v-if="router.currentRoute.value.name === 'track' && trackStore.track">
+            <div class="p-4 pt-3 text-sm h-[44px] dark:h-[45px] bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold capitalize">
+                <font-awesome-icon @click="gotoLibrary" icon="arrow-left" size="xl" class="ml-3 mr-6 cursor-pointer hover:text-ngreenhover" />
+                {{ trackStore.track.track_type }}
+            </div>
+        </template>
+        <!-- <template v-if="router.currentRoute.value.name === 'collection'">
             <div class="px-4 items-center h-[44px] dark:h-[45px] text-sm bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold">
                 <div v-for="(collection, index) in collectionSelector.collectionSelected" :key="index" class="flex w-full">
                     <font-awesome-icon @click="gotoLibrary" icon="arrow-left" size="xl" class="ml-3 mr-6 cursor-pointer hover:text-ngreenhover" />
@@ -791,26 +797,40 @@ function onDragStart($event, track) {
                     </div>
                 </div>
             </div>
-        </template>
-        <template v-if="router.currentRoute.value.name === 'track' && trackStore.track">
-            <div class="p-4 pt-3 text-sm h-[44px] dark:h-[45px] bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold capitalize">
-                <font-awesome-icon @click="gotoLibrary" icon="arrow-left" size="xl" class="ml-3 mr-6 cursor-pointer hover:text-ngreenhover" />
-                {{ trackStore.track.track_type }}
-            </div>
-        </template>
-        <template v-if="router.currentRoute.value.name === 'library'">
+        </template> -->
+        <template v-if="router.currentRoute.value.name === 'library' || router.currentRoute.value.name === 'collection'">
             <div class="px-4 py-1.5 pb-2 text-sm h-[44px] dark:h-[45px] bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold">
                 <div class="flex gap-2 w-full">
-                    <div class="py-1.5">
-                        <template v-if="selectedTracks.length === 0"> 
-                            {{ trackStore.tracks.length }} Results
-                        </template>
-                        <template v-else>
-                            {{ selectedTracks.length }} selected
+                    <div class="w-full">
+                        <div class="mr-auto py-1.5" v-if="router.currentRoute.value.name === 'library'">
+                            <template v-if="selectedTracks.length === 0"> 
+                                {{ trackStore.tracks.length }} Results
+                            </template>
+                            <template v-else>
+                                {{ selectedTracks.length }} selected
+                            </template>
+                        </div>
+                        <template v-if="router.currentRoute.value.name === 'collection'">
+                            <div v-for="(collection, index) in collectionSelector.collectionSelected" :key="index" class="flex w-full">
+                                <div class="py-1">
+                                    <font-awesome-icon @click="gotoLibrary" icon="arrow-left" size="xl" class="ml-3 mr-6 cursor-pointer hover:text-ngreenhover" />
+                                    {{ collection.name }} {{ collection.size > 0 ? `(${collection.size} tracks)` : '' }}
+                                </div>
+                                <div class="flex gap-2 ml-auto">
+                                    <button @click="browserStore.collectionModalEdit = collection; browserStore.collectionModal = true;" @click.stop class="whitespace-nowrap text-xs font-medium border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100">
+                                        <font-awesome-icon icon="pen" />
+                                        <span class="ml-2 mobilehide">Edit</span>
+                                    </button>
+                                    <button @click="downloadCollection(collection)" class="whitespace-nowrap text-xs font-medium border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
+                                        <font-awesome-icon icon="download" />
+                                        <span class="ml-2 mobilehide">Export</span>
+                                    </button>
+                                </div>
+                            </div>
                         </template>
                     </div>
                     <template v-if="selectedTracks.length === 0"> 
-                        <button @click="bulkContextMenu = !bulkContextMenu" class="text-sm font-medium ml-auto border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
+                        <button @click="bulkContextMenu = !bulkContextMenu" class="whitespace-nowrap text-xs font-medium border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
                             <font-awesome-icon icon="pen" class="mr-1" />
                             Edit all
                         </button>
@@ -820,7 +840,7 @@ function onDragStart($event, track) {
                         </div>
                     </template>
                     <template v-else> 
-                        <button @click="bulkContextMenu = !bulkContextMenu" class="text-sm font-medium ml-auto border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
+                        <button @click="bulkContextMenu = !bulkContextMenu" class="whitespace-nowrap text-xs font-medium border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
                             <font-awesome-icon icon="pen" class="mr-1" />
                             Edit selected
                         </button>
@@ -829,7 +849,7 @@ function onDragStart($event, track) {
                             <div class="flex p-3 hover:bg-gray-200 dark:hover:bg-[#3e3e3e] rounded cursor-pointer" @click="collectionTrack.value = 'selection'; browserStore.collectionModal = true; bulkContextMenu = false"><div class="w-6"><font-awesome-icon icon="bars" class="mt-0.5" /></div>Add selected to collection</div>
                         </div>
                     </template>
-                    <button @click="searchResultTableRowsConfigModalShow()" class="text-sm font-medium border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
+                    <button @click="searchResultTableRowsConfigModalShow()" class="whitespace-nowrap text-xs font-medium border dark:border-gray-700 hover:border-npurple rounded-md cursor-pointer px-3 py-1 text-gray-700 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100" @click.stop>
                         <font-awesome-icon icon="table-columns" class="mr-1" />
                         Display
                     </button>

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -780,24 +780,6 @@ function onDragStart($event, track) {
                 {{ trackStore.track.track_type }}
             </div>
         </template>
-        <!-- <template v-if="router.currentRoute.value.name === 'collection'">
-            <div class="px-4 items-center h-[44px] dark:h-[45px] text-sm bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold">
-                <div v-for="(collection, index) in collectionSelector.collectionSelected" :key="index" class="flex w-full">
-                    <font-awesome-icon @click="gotoLibrary" icon="arrow-left" size="xl" class="ml-3 mr-6 cursor-pointer hover:text-ngreenhover" />
-                    {{ collection.name }} {{ collection.size > 0 ? `(${collection.size} tracks)` : '' }}
-                    <div class="flex gap-2 ml-auto">
-                        <div @click="browserStore.collectionModalEdit = collection; browserStore.collectionModal = true;" @click.stop class="text-sm rounded-md px-2 items-center hover:text-npurple cursor-pointer font-medium">
-                            <font-awesome-icon icon="pen" />
-                            <span class="ml-2 mobilehide">Edit</span>
-                        </div>
-                        <div @click="downloadCollection(collection)" @click.stop class="text-sm rounded-md px-2 items-center hover:text-npurple cursor-pointer font-medium">
-                            <font-awesome-icon icon="download" />
-                            <span class="ml-2 mobilehide">Export</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </template> -->
         <template v-if="router.currentRoute.value.name === 'library' || router.currentRoute.value.name === 'collection'">
             <div class="px-4 py-1.5 pb-2 text-sm h-[44px] dark:h-[45px] bg-gradient-to-b from-gray-100 dark:from-ngreyblackhover border-b dark:border-black flex font-bold">
                 <div class="flex gap-2 w-full">

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -693,7 +693,7 @@ async function getTracks() {
 
 function onDragStart($event, track) {
     if (selectedTracks.value.length === 0) {
-        browserStore.draggableTracks = [track]
+        browserStore.draggableTracks = [track.id]
     } else {
         browserStore.draggableTracks = selectedTracks.value
     }

--- a/src/components/apps/nendo_library/nendo_library_main.vue
+++ b/src/components/apps/nendo_library/nendo_library_main.vue
@@ -110,6 +110,8 @@ onBeforeUnmount(() => {
 watch(
     () => route.fullPath,
     (to, from) => {
+        selectedTracks.value = []
+        browserStore.draggableTracks = []
         resetSearchInput()
     }
 )
@@ -524,6 +526,8 @@ const bulkDelete = async () => {
             collectionSelector.value.collectionSelected = [collectionStore.collection]
         }
         getTracks()
+        selectedTracks.value = []
+        browserStore.draggableTracks = []
     }
 }
 
@@ -537,6 +541,8 @@ const selectionDelete = async () => {
             collectionSelector.value.collectionSelected = [collectionStore.collection]
         }
         getTracks()
+        selectedTracks.value = []
+        browserStore.draggableTracks = []
     }
 }
 
@@ -812,7 +818,7 @@ function onDragStart($event, track) {
                             <font-awesome-icon icon="pen" class="mr-1" />
                             Edit all
                         </button>
-                        <div v-show="bulkContextMenu" @click="bulkContextMenu = false" @click.stop class="group-hover:visible origin-top-right absolute right-4 mt-8 w-56 p-1 rounded-md shadow-lg bg-gray-100 dark:bg-[#282828] ring-1 ring-black ring-opacity-5 focus:outline-none z-50">
+                        <div v-show="bulkContextMenu" @click="bulkContextMenu = false" @click.stop class="group-hover:visible origin-top-right absolute right-4 mt-8 w-56 p-1 rounded-md shadow-lg bg-gray-100 dark:bg-[#282828] ring-1 ring-black ring-opacity-5 focus:outline-none z-50 font-normal">
                             <div class="flex p-3 hover:bg-gray-200 dark:hover:bg-[#3e3e3e] rounded cursor-pointer" @click="bulkDelete()"><div class="w-6"><font-awesome-icon icon="x" class="mt-0.5" /></div>Delete All</div>
                             <div class="flex p-3 hover:bg-gray-200 dark:hover:bg-[#3e3e3e] rounded cursor-pointer" @click="collectionTrack.value = 'bulk'; browserStore.collectionModal = true; bulkContextMenu = false"><div class="w-6"><font-awesome-icon icon="bars" class="mt-0.5" /></div>Add all to collection</div>
                         </div>
@@ -822,7 +828,7 @@ function onDragStart($event, track) {
                             <font-awesome-icon icon="pen" class="mr-1" />
                             Edit selected
                         </button>
-                        <div v-show="bulkContextMenu" @click="bulkContextMenu = false" @click.stop class="group-hover:visible origin-top-right absolute right-4 mt-8 w-56 p-1 rounded-md shadow-lg bg-gray-100 dark:bg-[#282828] ring-1 ring-black ring-opacity-5 focus:outline-none z-50">
+                        <div v-show="bulkContextMenu" @click="bulkContextMenu = false" @click.stop class="group-hover:visible origin-top-right absolute right-4 mt-8 w-56 p-1 rounded-md shadow-lg bg-gray-100 dark:bg-[#282828] ring-1 ring-black ring-opacity-5 focus:outline-none z-50 font-normal">
                             <div class="flex p-3 hover:bg-gray-200 dark:hover:bg-[#3e3e3e] rounded cursor-pointer" @click="selectionDelete()"><div class="w-6"><font-awesome-icon icon="x" class="mt-0.5" /></div>Delete selection</div>
                             <div class="flex p-3 hover:bg-gray-200 dark:hover:bg-[#3e3e3e] rounded cursor-pointer" @click="collectionTrack.value = 'selection'; browserStore.collectionModal = true; bulkContextMenu = false"><div class="w-6"><font-awesome-icon icon="bars" class="mt-0.5" /></div>Add selected to collection</div>
                         </div>

--- a/src/components/apps_components/component_collection.vue
+++ b/src/components/apps_components/component_collection.vue
@@ -164,7 +164,11 @@ async function collectionSelected(collection) {
         if (selectedIndex === -1) {
             collectionAddSelector.value.push(collection.id)
             if (props.track.value === 'bulk'){
-                await addTracksToCollection(collection, props.trackTypeFilter)
+                await addTracksToCollection(
+                    collection,
+                    router.currentRoute.value.name === 'collection' ? route.params.id : '',
+                    props.trackTypeFilter
+                )
             } else {
                 await addTrackToCollection(collection, props.track.value)
             }
@@ -195,9 +199,13 @@ const addTrackToCollection = async (collection, track) => {
     getCollections()
 }
 
-const addTracksToCollection = async (collection, trackTypeFilter) => {
+const addTracksToCollection = async (collection, relatedCollectionId, trackTypeFilter) => {
     await collectionStore.addTracksToCollection(
-        collection.id, trackTypeFilter
+        collection.id,
+        {
+            relatedCollectionId: relatedCollectionId,
+            trackType: trackTypeFilter
+        }
     )
 }
 
@@ -221,6 +229,7 @@ const handleSearchInput = debounce((event) => {
 const closeModal = async (collection, track) => {
     browserStore.collectionModalAdd = false
     browserStore.collectionModalEdit = false
+    // collectionSelector.value.collectionSelected = [props.collection]
     emit('modalClosed', {collection: collectionSelector, addTrack: collectionAddTrack, track: props.track})
 }
 

--- a/src/components/apps_components/component_collection.vue
+++ b/src/components/apps_components/component_collection.vue
@@ -2,14 +2,23 @@
 import { ref,    onMounted, computed } from 'vue'
 import { useCollectionStore } from '@/stores/collection'
 import { debounce } from 'lodash'
-import { useBrowserStore } from '../../stores/browser';
+import { useBrowserStore } from '../../stores/browser'
+import { useRouter, useRoute } from 'vue-router'
 
 const collectionStore = useCollectionStore()
 const browserStore = useBrowserStore()
 
+// router
+const router = useRouter()
+const route = useRoute()
+
 const props = defineProps({
     track: {
         type: Object,
+        required: true
+    },
+    trackTypeFilter: {
+        type: String,
         required: true
     },
     collection: {
@@ -54,8 +63,14 @@ function setTitle() {
         collectionAddTrack.value = true
 
         collectionAddSelector.value = []
-        for (let i=0; i < props.track.value.related_collections.length; i++) {
-            collectionAddSelector.value.push(props.track.value.related_collections[i].target.id)
+        if (props.track.value !== 'bulk') {
+            for (let i=0; i < props.track.value.related_collections.length; i++) {
+                collectionAddSelector.value.push(props.track.value.related_collections[i].target.id)
+            }
+        } else {
+            if (router.currentRoute.value.name === 'collection') {
+                collectionAddSelector.value.push(route.params.id)
+            }
         }
     }
 }
@@ -127,7 +142,7 @@ function isCollectionSelected(collection) {
     return collectionSelector.value.collectionSelected.some(selected => selected.id === collection.id);
 }
 
-function collectionSelected(collection) {
+async function collectionSelected(collection) {
     // go to collection
     if (!collectionAddTrack.value) {
         let selectedIndex = collectionSelector.value.collectionSelected.findIndex(
@@ -141,17 +156,25 @@ function collectionSelected(collection) {
             emit('modalClosed', {collection: collectionSelector, addTrack: collectionAddTrack})
         }
     }    
-    // add/remove track to collection
+    // add/remove track(s) to collection
     if (collectionAddTrack.value) {
         let selectedIndex = collectionAddSelector.value.findIndex(
             (option) => option === collection.id
         )
         if (selectedIndex === -1) {
             collectionAddSelector.value.push(collection.id)
-            addTrackToCollection(collection, props.track.value)
+            if (props.track.value === 'bulk'){
+                await addTracksToCollection(collection, props.trackTypeFilter)
+            } else {
+                await addTrackToCollection(collection, props.track.value)
+            }
         } else {
             collectionAddSelector.value.splice(selectedIndex, 1)
-            removeTrackFromCollection(collection, props.track.value)
+            if (props.track.value === 'bulk'){
+                await removeTracksFromCollection(collection, props.trackTypeFilter)
+            } else {
+                await removeTrackFromCollection(collection, props.track.value)
+            }
         }
     }    
 }
@@ -170,6 +193,18 @@ const addTrackToCollection = async (collection, track) => {
         collection.id, track.id
     )
     getCollections()
+}
+
+const addTracksToCollection = async (collection, trackTypeFilter) => {
+    await collectionStore.addTracksToCollection(
+        collection.id, trackTypeFilter
+    )
+}
+
+const removeTracksFromCollection = async (collection, trackTypeFilter) => {
+    await collectionStore.removeTracksFromCollection(
+        collection.id, trackTypeFilter
+    )
 }
 
 const removeTrackFromCollection = async (collection, track) => {

--- a/src/components/shell/Sidebar.vue
+++ b/src/components/shell/Sidebar.vue
@@ -127,11 +127,9 @@ const drop = (event, collection) => {
 };
 
 async function handleDroppedItem (collection) {
-    for(let i=0; i< browserStore.draggableTracks.length; i++) {
-        await collectionStore.addTrackToCollection(
-            collection.id, browserStore.draggableTracks[i].id
-        )
-    }
+    await collectionStore.addSelectedTracksToCollection(
+        collection.id, browserStore.draggableTracks
+    )
     if (browserStore.draggableTracks.length > 0) {
         useToast().success(browserStore.draggableTracks.length + ' tracks added to: ' + collection.name)
     } else {

--- a/src/components/shell/Sidebar.vue
+++ b/src/components/shell/Sidebar.vue
@@ -4,6 +4,7 @@ import { useBrowserStore } from '@/stores/browser.js'
 import { useCollectionStore } from '@/stores/collection'
 import { debounce } from 'lodash'
 import { useRouter } from 'vue-router'
+import { useToast } from 'vue-toast-notification'
 
 const router = useRouter()
 const browserStore = useBrowserStore()
@@ -109,6 +110,36 @@ const addCollection = () => {
     }
 } 
 
+// drag n drop 
+const dragEnter = (event, collection) => {
+    event.target.style.backgroundColor = 'rgba(96,93,255,0.3)'
+};
+
+const dragLeave = (event, collection) => {
+    event.target.style.backgroundColor = ''
+};
+
+const drop = (event, collection) => {
+    event.preventDefault();
+    event.target.style.backgroundColor = ''
+    // const data = event.dataTransfer.getData("text/plain");
+    handleDroppedItem(collection);
+};
+
+async function handleDroppedItem (collection) {
+    for(let i=0; i< browserStore.draggableTracks.length; i++) {
+        await collectionStore.addTrackToCollection(
+            collection.id, browserStore.draggableTracks[i].id
+        )
+    }
+    if (browserStore.draggableTracks.length > 0) {
+        useToast().success(browserStore.draggableTracks.length + ' tracks added to: ' + collection.name)
+    } else {
+        useToast().success('Track added to: ' + collection.name)
+    }
+}
+
+
 </script>
 
 <template>
@@ -164,7 +195,10 @@ const addCollection = () => {
                     class="flex items-center px-6 py-3 flex hover:bg-gray-100 dark:hover:bg-ngreytransparent cursor-pointer text-gray-600 dark:text-gray-300"
                     :class="{ 'bg-gray-100 dark:bg-ngreytransparent font-medium text-black dark:text-gray-100' : isCollectionSelected(collection) }"
                     @click="gotoCollection(collection)"
-                    @click.stop
+                    @dragover.prevent 
+                    @dragenter="dragEnter($event, collection)"
+                    @dragleave="dragLeave($event, collection)"
+                    @drop="drop($event, collection)"
                 >
                     <div class="mr-1">
                         <font-awesome-icon icon="list" class="mr-3 mt-0.5" />

--- a/src/stores/browser.js
+++ b/src/stores/browser.js
@@ -17,6 +17,7 @@ export const useBrowserStore = defineStore({
         audioPlayerSeek: 0,
         audioEngine: null,
         isMobile: false,
+        draggableTracks: [],
         export: {
             modal: false,
             track: null,

--- a/src/stores/collection.js
+++ b/src/stores/collection.js
@@ -297,6 +297,40 @@ export const useCollectionStore = defineStore({
                 this.loading = false
             }
         },
+        async addSelectedTracksToCollection(collectionId, trackIds) {
+            const sessionStore = useSessionStore()
+            if (collectionId === undefined) {
+                return
+            }
+            console.log(trackIds)
+
+            this.loading = true
+            try {
+                const collectionUrl = `${BASE_API_URL}/api/v1/collections/${collectionId}/tracks/selected`
+                const response = await fetch(
+                    collectionUrl,
+                    {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Authorization: `Bearer ${sessionStore.getToken()}`
+                        },
+                        body: JSON.stringify(trackIds)
+                    }
+                )
+
+                if (response.status === 401) {
+                    await router.push('/login')
+                }
+
+                const data = await response.json()
+                return data
+            } catch (error) {
+                this.error = error
+            } finally {
+                this.loading = false
+            }
+        },
         async addTracksToCollection(collectionId, options = {}) {
             const {
                 relatedCollectionId = null,
@@ -365,6 +399,39 @@ export const useCollectionStore = defineStore({
                 //CLOSE MODAL
                 // this.collectionIdToAddTrackTo = undefined
                 // this.trackIdToAddToCollection = undefined
+            }
+        },
+        async removeSelectedTracksFromCollection(collectionId, trackIds) {
+            const sessionStore = useSessionStore()
+            if (collectionId === undefined) {
+                return
+            }
+
+            this.loading = true
+            try {
+                const collectionUrl = `${BASE_API_URL}/api/v1/collections/${collectionId}/tracks/selected`
+                const response = await fetch(
+                    collectionUrl,
+                    {
+                        method: 'PATCH',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Authorization: `Bearer ${sessionStore.getToken()}`
+                        },
+                        body: JSON.stringify(trackIds)
+                    }
+                )
+
+                if (response.status === 401) {
+                    await router.push('/login')
+                }
+
+                const data = await response.json()
+                return data
+            } catch (error) {
+                this.error = error
+            } finally {
+                this.loading = false
             }
         },
         async removeTracksFromCollection(collectionId, trackType) {

--- a/src/stores/collection.js
+++ b/src/stores/collection.js
@@ -178,7 +178,6 @@ export const useCollectionStore = defineStore({
                 const data = await response.json()
                 this.collection = data.data.collection
                 this.collection.size = data.data.size
-
                 return this.collection
             } catch (error) {
                 this.error = error
@@ -298,7 +297,11 @@ export const useCollectionStore = defineStore({
                 this.loading = false
             }
         },
-        async addTracksToCollection(collectionId, trackType) {
+        async addTracksToCollection(collectionId, options = {}) {
+            const {
+                relatedCollectionId = null,
+                trackType = null
+            } = options
             const sessionStore = useSessionStore()
             if (collectionId === undefined) {
                 return
@@ -309,7 +312,7 @@ export const useCollectionStore = defineStore({
                 const searchFilterParams = this.getSearchFilterParams()
                 const collectionUrl = `${BASE_API_URL}/api/v1/collections/${collectionId}/tracks?search_filter=${encodeURIComponent(
                     JSON.stringify(searchFilterParams)
-                )}&track_type=${trackType}`
+                )}&track_type=${trackType}&related_collection_id=${relatedCollectionId}`
                 const response = await fetch(
                     collectionUrl,
                     {

--- a/src/stores/track.js
+++ b/src/stores/track.js
@@ -85,6 +85,8 @@ export const useTrackStore = defineStore({
             const sessionStore = useSessionStore()
             const {
                 similarTo = null,
+                relationshipType = null,
+                relationship_id = null,
                 fetch_related = false,
                 track_id = null,
                 collection_id = null,
@@ -146,13 +148,13 @@ export const useTrackStore = defineStore({
 
                 const result = await response.json()
                 this.hasNext = result.has_next
+                this.num_results = result.data.num_results
 
                 if (!append) {
                     this.tracks = result.data.tracks
                 } else {
                     this.tracks.push(...result.data.tracks)
                 }
-                this.num_results = result.data.num_results
             } catch (error) {
                 this.error = error
             } finally {
@@ -183,9 +185,8 @@ export const useTrackStore = defineStore({
                     await router.push('/library')
                 }
 
-                const data = await response.json()
-                const result = data.data
-                this.track = result
+                const result = await response.json()
+                this.track = result.data
             } catch (error) {
                 this.error = error
             } finally {
@@ -270,6 +271,33 @@ export const useTrackStore = defineStore({
                         }
                     }
                 )
+
+                if (response.status === 401) {
+                    await router.push('/login')
+                }
+
+                const data = await response.json()
+                return data
+            } catch (error) {
+                this.error = error
+            } finally {
+                this.loading = false
+            }
+        },
+        async deleteSelectedTracks(trackIds) {
+            const sessionStore = useSessionStore()
+            this.loading = true
+            try {
+                const searchFilterParams = this.getSearchFilterParams()
+                let tracksUrl = `${BASE_API_URL}/api/v1/tracks/selected`
+                const response = await fetch(tracksUrl, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${sessionStore.getToken()}`
+                    },
+                    body: JSON.stringify(trackIds)
+                })
 
                 if (response.status === 401) {
                     await router.push('/login')

--- a/src/stores/track.js
+++ b/src/stores/track.js
@@ -12,6 +12,7 @@ export const useTrackStore = defineStore({
     id: 'track',
     state: () => ({
         tracks: [],
+        num_results: 0,
         cursor: 0,
         hasNext: false,
         track: {},
@@ -84,8 +85,6 @@ export const useTrackStore = defineStore({
             const sessionStore = useSessionStore()
             const {
                 similarTo = null,
-                relationshipType = null,
-                relationship_id = null,
                 fetch_related = false,
                 track_id = null,
                 collection_id = null,
@@ -145,14 +144,15 @@ export const useTrackStore = defineStore({
                     useToast().error("Cannot find track embedding. Generate an embeding first.")
                 }
 
-                const data = await response.json()
-                this.hasNext = data.has_next
+                const result = await response.json()
+                this.hasNext = result.has_next
 
                 if (!append) {
-                    this.tracks = data.data
+                    this.tracks = result.data.tracks
                 } else {
-                    this.tracks.push(...data.data)
+                    this.tracks.push(...result.data.tracks)
                 }
+                this.num_results = result.data.num_results
             } catch (error) {
                 this.error = error
             } finally {

--- a/src/stores/track.js
+++ b/src/stores/track.js
@@ -282,6 +282,38 @@ export const useTrackStore = defineStore({
             } finally {
                 this.loading = false
             }
-        }
+        },
+        async deleteTracks(options = {}) {
+            const sessionStore = useSessionStore()
+            const {
+                collection_id = null,
+                track_type = null
+            } = options
+            this.loading = true
+            try {
+                const searchFilterParams = this.getSearchFilterParams()
+                let tracksUrl = `${BASE_API_URL}/api/v1/tracks?search_filter=${encodeURIComponent(
+                    JSON.stringify(searchFilterParams)
+                )}&track_type=${track_type}&collection_id=${collection_id}`
+                const response = await fetch(tracksUrl, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${sessionStore.getToken()}`
+                    }
+                })
+
+                if (response.status === 401) {
+                    await router.push('/login')
+                }
+
+                const data = await response.json()
+                return data
+            } catch (error) {
+                this.error = error
+            } finally {
+                this.loading = false
+            }
+        },
     }
 })


### PR DESCRIPTION
This PR introduces a new button in the library that allows to add all tracks returned by the current view (according to collection, filters and search text) as a new collection. The button's menu also has an option for bulk deletion of all tracks.

Related server PR: https://github.com/okio-ai/nendo-server/pull/7